### PR TITLE
Make single-replica restore work

### DIFF
--- a/axlearn/common/checkpointer_orbax.py
+++ b/axlearn/common/checkpointer_orbax.py
@@ -202,7 +202,7 @@ class OrbaxCheckpointer(BaseCheckpointer):
         async_timeout_secs: int = 500
         max_concurrent_save_gb: Optional[int] = None
         max_concurrent_restore_gb: Optional[int] = None
-        enable_single_replica_ckpt_restoring: bool = False
+        enable_single_replica_ckpt_restoring: bool = True
         use_replica_parallel: bool = False
 
     @classmethod
@@ -352,7 +352,7 @@ class OrbaxCheckpointer(BaseCheckpointer):
 
         if cfg.enable_single_replica_ckpt_restoring:
             array_handler = ocp.type_handlers.SingleReplicaArrayHandler(
-                replica_axis_index=0,
+                replica_axis_index=1,
                 broadcast_memory_limit_bytes=1024 * 1024 * 1000,  # 1000 MB limit
             )
             ocp.type_handlers.register_type_handler(jax.Array, array_handler, override=True)
@@ -362,7 +362,7 @@ class OrbaxCheckpointer(BaseCheckpointer):
                 if cfg.enable_single_replica_ckpt_restoring:
                     pspec = x.sharding.spec
                     mesh = x.sharding.mesh
-                    replica_axis_index = 0
+                    replica_axis_index = 1
                     replica_devices = _replica_devices(mesh.devices, replica_axis_index)
                     replica_mesh = jax.sharding.Mesh(replica_devices, mesh.axis_names)
                     single_replica_sharding = jax.sharding.NamedSharding(replica_mesh, pspec)

--- a/axlearn/experiments/text/gpt/common.py
+++ b/axlearn/experiments/text/gpt/common.py
@@ -718,7 +718,7 @@ def get_trainer_config_fn(
         )
         ckpt_config.keep_last_n = 3
         ckpt_config.keep_every_n_steps = min(max_step, keep_every_n_steps)
-        ckpt_config.enable_single_replica_ckpt_restoring = False
+        ckpt_config.enable_single_replica_ckpt_restoring = True
         ckpt_config.use_replica_parallel = False
         cfg.checkpointer = ckpt_config
         ########################################################################


### PR DESCRIPTION
Confirmed that this runs and replica 0 has logs that [correspond to single-replica restore in Orbax](https://github.com/google/orbax/blob/203d0853e1fbbcb063b9fac859cbfe918c84d190/checkpoint/orbax/checkpoint/_src/serialization/type_handlers.py#L1591C19-L1591C43)

As best as I can tell the replica axis index corresponds to the axis originally defined [here](https://github.com/apple/axlearn/blob/39f69bc56149c2fa572ff33d4af16cb05432679b/axlearn/experiments/text/gpt/common.py#L188), i.e. we want axis 1 in order to use replicas based on data-parallelism